### PR TITLE
free valuePtr when closing TrailDBConstructor

### DIFF
--- a/tdb.go
+++ b/tdb.go
@@ -195,6 +195,7 @@ func (cons *TrailDBConstructor) GetOpt(key int, value int) (int, error) {
 }
 
 func (cons *TrailDBConstructor) Close() {
+	defer C.free(cons.valuePtr)
 	C.tdb_cons_close(cons.cons)
 }
 


### PR DESCRIPTION
to avoid memory leak