### PR TITLE
Check Open file extension

### DIFF
--- a/tdb.go
+++ b/tdb.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 )
 
 import "unsafe"
@@ -214,6 +215,10 @@ func exists(path string) (bool, error) {
 }
 
 func Open(s string) (*TrailDB, error) {
+	if !strings.HasSuffix(s, ".tdb") {
+		s = s + ".tdb"
+	}
+
 	ok, er := exists(s)
 	if er != nil {
 		return nil, er


### PR DESCRIPTION
Hi,

Using this, I found that:
`cons, err := tdb.NewTrailDBConstructor("forum", "action")`
Create a `forum.tdb` file

Otherwise, to manage this file with Open, I must do this:
`db, err := tdb.Open("forum.tdb")`

This file call caused me some strange case (having forum.tdb.tdb file, or no file found). I've made a small tricks to allow the same usage between `NewTrailDBConstructor` and `Open` without file extension.